### PR TITLE
Fixed bug when passing a matrix to transformPointCloud.

### DIFF
--- a/pycpd/affine_registration.py
+++ b/pycpd/affine_registration.py
@@ -58,7 +58,7 @@ class affine_registration(object):
     self.t = np.transpose(muX) - np.dot(self.B, np.transpose(muY))
 
   def transformPointCloud(self, Y=None):
-    if not Y:
+    if Y is None:
       self.TY = np.dot(self.Y, np.transpose(self.B)) + np.tile(np.transpose(self.t), (self.M, 1))
       return
     else:

--- a/pycpd/deformable_registration.py
+++ b/pycpd/deformable_registration.py
@@ -48,7 +48,7 @@ class deformable_registration(object):
     self.W = np.linalg.solve(A, B)
 
   def transformPointCloud(self, Y=None):
-    if not Y:
+    if Y is None:
       self.TY = self.Y + np.dot(self.G, self.W)
       return
     else:

--- a/pycpd/rigid_registration.py
+++ b/pycpd/rigid_registration.py
@@ -64,7 +64,7 @@ class rigid_registration(object):
     self.t = np.transpose(muX) - self.s * np.dot(self.R, np.transpose(muY))
 
   def transformPointCloud(self, Y=None):
-    if not Y:
+    if Y is None:
       self.TY = self.s * np.dot(self.Y, np.transpose(self.R)) + np.tile(np.transpose(self.t), (self.M, 1))
       return
     else:


### PR DESCRIPTION
The existing code uses the test "if not Y" to check if a matrix of points has been passed to the funciton. However, this syntax throws an error when Y is neither "None" nor a Boolean.

Changed test to "if Y is None", which tests specifically for the default case of transformPointCloud(Y=None)