### PR TITLE
modify fish_deformable_3D example and test the deform algorithm; chan…

### DIFF
--- a/examples/fish_deformable_3D.py
+++ b/examples/fish_deformable_3D.py
@@ -18,22 +18,28 @@ def main():
     fish_target = np.loadtxt('data/fish_target.txt')
     X1 = np.zeros((fish_target.shape[0], fish_target.shape[1] + 1))
     X1[:,:-1] = fish_target
-    X2 = np.ones((fish_target.shape[0], fish_target.shape[1] + 1))
-    X2[:,:-1] = fish_target
-    X = np.vstack((X1, X2))
+
+    theta = np.pi / 6.0
+    R = np.array([[np.cos(theta), -np.sin(theta)], [np.sin(theta), np.cos(theta)]])
+    t = np.array([0.5, 1.0])
+
+    X1[:,:-1] = np.dot(X1[:,:-1], R) + np.tile(t, (np.shape(X1[:,:-1])[0], 1))
+    # X2 = np.ones((fish_target.shape[0], fish_target.shape[1] + 1))
+    # X2[:,:-1] = fish_target
+    # X = np.vstack((X1, X2))
 
     fish_source = np.loadtxt('data/fish_source.txt')
     Y1 = np.zeros((fish_source.shape[0], fish_source.shape[1] + 1))
     Y1[:,:-1] = fish_source
-    Y2 = np.ones((fish_source.shape[0], fish_source.shape[1] + 1))
-    Y2[:,:-1] = fish_source
-    Y = np.vstack((Y1, Y2))
+    # Y2 = np.ones((fish_source.shape[0], fish_source.shape[1] + 1))
+    # Y2[:,:-1] = fish_source
+    # Y = np.vstack((Y1, Y2))
 
     fig = plt.figure()
     ax = fig.add_subplot(111, projection='3d')
     callback = partial(visualize, ax=ax)
 
-    reg = deformable_registration(**{ 'X': X, 'Y': Y })
+    reg = deformable_registration(**{ 'X': X1, 'Y': Y1 })
     reg.register(callback)
     plt.show()
 

--- a/pycpd/deformable_registration.py
+++ b/pycpd/deformable_registration.py
@@ -40,7 +40,11 @@ class deformable_registration(expectation_maximization_registration):
         yPy      = np.dot(np.transpose(self.P1),  np.sum(np.multiply(self.Y, self.Y), axis=1))
         trPXY    = np.sum(np.multiply(self.Y, np.dot(self.P, self.X)))
 
-        self.sigma2 = (xPx - trPXY) / (self.Np * self.D)
+        X_dPt1_X = np.matmul(np.transpose(self.X), np.matmul(np.diag(self.Pt1), self.X))
+        P_XT_TY = np.matmul(np.transpose(np.matmul(self.P, self.X)), self.TY)
+        TYT_dP1_TY = np.matmul(np.transpose(self.TY), np.matmul(np.diag(self.P1), self.TY))
+        self.sigma2 = (np.trace(X_dPt1_X) - 2 * np.trace(P_XT_TY) +
+                       np.trace(TYT_dP1_TY)) / (self.Np * self.D)
 
         if self.sigma2 <= 0:
             self.sigma2 = self.tolerance / 10


### PR DESCRIPTION
The fish_deformable_3D.py example is not sufficient to demo the correctness of the cpd algorithm. When I apply a R, t to the X point cloud, the fish_deformable_3D.py fails. 

After I recheck the formula in the cpd paper, the initial implementation of sigma2 update seems not correct. I change the sigma2 update according to what's described here:
![screenshot 2018-08-20 23 06 06](https://user-images.githubusercontent.com/15709515/44378094-b5ca8700-a4cd-11e8-9f88-ea2fae22d794.png)
